### PR TITLE
Quickstart add request: getupcloud/openshift-cartridge-elasticsearch

### DIFF
--- a/wsgi/static/quickstart.json
+++ b/wsgi/static/quickstart.json
@@ -1,5 +1,28 @@
 [
-{
+   {
+      "updated_at": "2014-07-10T22:29:32Z", 
+      "owner": "https://github.com/getupcloud", 
+      "id": 21712499, 
+      "description": "OpenShift ElasticSearch Cartridge", 
+      "size": 0, 
+      "forks": 0, 
+      "watchers": 0, 
+      "name": "openshift-cartridge-elasticsearch", 
+      "language": "Shell", 
+      "created_at": "2014-07-10T22:29:08Z", 
+      "stargazers": 0, 
+      "owner_type": "User", 
+      "default_app_name": "elasticsearch", 
+      "cartridges": [
+         ""
+      ], 
+      "git_repo_url": "https://github.com/getupcloud/openshift-cartridge-elasticsearch.git", 
+      "type": "cartridge", 
+      "submitted_at": "2014-07-17T16:57:23.578269", 
+      "owner_name": "Getup Cloud", 
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/3430018?"
+   }, 
+   {
       "updated_at": "2014-06-24T12:54:34Z", 
       "owner": "https://github.com/rkmallik", 
       "id": 18625938, 


### PR DESCRIPTION
Automatically generated PR for oo-index
